### PR TITLE
Let bloom infer the version from master.

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -12,15 +12,15 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: null
+    devel_branch: master
     last_release: 0.5.0_crystal
     last_version: 0.5.0
     name: ros2_object_analytics
     patches: null
     release_inc: '0'
     release_repo_url: null
-    release_tag: 0.5.0_crystal
+    release_tag: :{version}
     ros_distro: crystal
     vcs_type: git
     vcs_uri: https://github.com/intel/ros2_object_analytics.git
-    version: 0.5.0
+    version: :{auto}


### PR DESCRIPTION
Bloom can automatically choose the version to release by looking at the version in the devel branch package.xml (as long as a devel branch is set.

So this change

1. Sets the devel branch to master.
2. Sets the version to be released to `:{auto}`, a special value that will tell bloom to check the devel branch.
3. Sets the release tag to `:{version}`, a special value which tells bloom to use the version as the tag value. I see that you have both plain `0.5.1` tags and `0.5.1_crystal` tags. The tag with just the version (`0.5.1`) is more common but if you wanted to keep using the _crystal suffix you could mix the special value with the crystal suffix `:{version}_crystal`. But it's most common to just use `:{version}`.